### PR TITLE
Update textbook link under Resources

### DIFF
--- a/resources.html
+++ b/resources.html
@@ -9,11 +9,8 @@ weight: 0
         <h2 class="title">Course Textbook</h2>
         <p>
             The course notes can be found
-            <a href="{{ site.baseurl }}/static/cs181-textbook.pdf">here</a>.
-            Corrections or improvements are welcome
-            <a href="https://github.com/harvard-ml-courses/cs181-textbook/blob/master/Textbook.pdf" target="_blank">
-                in the corresponding GitHub repository
-            </a>.
+            <a href="https://github.com/harvard-ml-courses/cs181-textbook/blob/master/Textbook.pdf">here</a>.
+            Corrections or improvements are welcome in the corresponding GitHub repository.
         </p>
 
         <h2 class="title" id="previous">Previous years of CS 1810</h2>


### PR DESCRIPTION
Change the link to the textbook to be the GitHub repository, so that it remains in sync.